### PR TITLE
feat: fall back to DEFAULT_* Power BI credentials when none are supplied

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,8 +14,8 @@ OPENAI_MODEL=gpt-4o-mini
 # ====================
 # OPTIONAL: Default Power BI Credentials
 # ====================
-# These can be provided at runtime, but setting defaults speeds up testing
-# WARNING: Only use for development. In production, provide credentials at runtime
+# These values are used if the `connect_powerbi` action does not provide
+# tenant_id, client_id or client_secret. Only use for local testing.
 
 # Azure AD Tenant ID (from Azure Portal)
 DEFAULT_TENANT_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx

--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ OPENAI_API_KEY=your_openai_api_key_here
 OPENAI_MODEL=gpt-4o-mini  # Optional: defaults to gpt-4o-mini
 
 # Optional: Default Power BI Credentials
+# These values are used when the `connect_powerbi` action does not supply
+# tenant_id, client_id or client_secret.
 DEFAULT_TENANT_ID=your_tenant_id
 DEFAULT_CLIENT_ID=your_client_id
 DEFAULT_CLIENT_SECRET=your_client_secret

--- a/quickstart.py
+++ b/quickstart.py
@@ -124,10 +124,10 @@ def check_environment():
         print(f"{Colors.YELLOW}Add OPENAI_API_KEY to your .env file{Colors.END}")
         return False
     
-    # Check optional Power BI credentials
+    # Check optional Power BI credentials used as fallback
     tenant_id = os.getenv("DEFAULT_TENANT_ID")
     if tenant_id:
-        print(f"{Colors.GREEN}✓ Default Power BI credentials found (optional){Colors.END}")
+        print(f"{Colors.GREEN}✓ Default Power BI credentials found (fallback){Colors.END}")
     else:
         print(f"{Colors.YELLOW}ℹ Default Power BI credentials not set (optional){Colors.END}")
     

--- a/src/server.py
+++ b/src/server.py
@@ -388,12 +388,12 @@ class PowerBIMCPServer:
                         "type": "object",
                         "properties": {
                             "xmla_endpoint": {"type": "string", "description": "Power BI XMLA endpoint URL"},
-                            "tenant_id": {"type": "string", "description": "Azure AD Tenant ID"},
-                            "client_id": {"type": "string", "description": "Service Principal Client ID"},
-                            "client_secret": {"type": "string", "description": "Service Principal Client Secret"},
+                            "tenant_id": {"type": "string", "description": "Azure AD Tenant ID (optional)"},
+                            "client_id": {"type": "string", "description": "Service Principal Client ID (optional)"},
+                            "client_secret": {"type": "string", "description": "Service Principal Client Secret (optional)"},
                             "initial_catalog": {"type": "string", "description": "Dataset name"}
                         },
-                        "required": ["xmla_endpoint", "tenant_id", "client_id", "client_secret", "initial_catalog"]
+                        "required": ["xmla_endpoint", "initial_catalog"]
                     }
                 ),
                 Tool(
@@ -485,13 +485,23 @@ class PowerBIMCPServer:
         try:
             with self.connection_lock:
                 # Connect to Power BI
+                tenant_id = arguments.get("tenant_id") or os.getenv("DEFAULT_TENANT_ID")
+                client_id = arguments.get("client_id") or os.getenv("DEFAULT_CLIENT_ID")
+                client_secret = arguments.get("client_secret") or os.getenv("DEFAULT_CLIENT_SECRET")
+
+                if not all([tenant_id, client_id, client_secret]):
+                    return (
+                        "Missing credentials. Provide tenant_id, client_id, and client_secret "
+                        "either in the action arguments or via DEFAULT_* values in the .env file."
+                    )
+
                 await asyncio.get_event_loop().run_in_executor(
                     None,
                     self.connector.connect,
                     arguments["xmla_endpoint"],
-                    arguments["tenant_id"],
-                    arguments["client_id"],
-                    arguments["client_secret"],
+                    tenant_id,
+                    client_id,
+                    client_secret,
                     arguments["initial_catalog"]
                 )
                 


### PR DESCRIPTION
## What’s new
1. `connect_powerbi` no longer requires tenant_id, client_id or client_secret  
   • If any of those fields are missing, the server now tries the corresponding `DEFAULT_*` values from `.env`.  
2. Updated docs and examples  
   • `.env.example`, `README.md` and startup messages clearly explain the new fallback behaviour.  
3. Relaxed JSON schema for the action  
   • Only `xmla_endpoint` and `initial_catalog` remain mandatory.  
4. Improved runtime validation  
   • If neither explicit values nor `DEFAULT_*` variables are available, the server returns a helpful error message instead of crashing.

## Why
• Simplifies local development and automated testing—developers can keep test credentials in `.env` and omit them from each request.  
• Keeps production safe: credentials can still be provided explicitly in secure environments.

## Testing
```bash
pytest -q          # still passes when libmono is available
python quickstart.py   # verifies fallback messages
```

## Ticket / Reference
https://chatgpt.com/codex/tasks/task_b_686e64a81be08329a1229f1e1d83bca9