### PR TITLE
Load platform dependencies for ADOMD.NET

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -106,15 +106,19 @@ if clr:
         if not path:
             continue
         if os.path.exists(path):
-            dll = os.path.join(path, "Microsoft.AnalysisServices.AdomdClient.dll")
+            dll_adomd = os.path.join(path, "Microsoft.AnalysisServices.AdomdClient.dll")
+            dll_core = os.path.join(path, "Microsoft.AnalysisServices.Platform.Core.dll")
+            dll_win = os.path.join(path, "Microsoft.AnalysisServices.Platform.Windows.dll")
             try:
                 sys.path.append(path)
-                clr.AddReference(dll)
+                clr.AddReference(dll_core)
+                clr.AddReference(dll_win)
+                clr.AddReference(dll_adomd)
                 adomd_loaded = True
-                logger.info("Loaded ADOMD.NET from %s", dll)
+                logger.info("Loaded ADOMD.NET from %s", dll_adomd)
                 break
             except Exception as e:  # pragma: no cover - best effort
-                logger.warning("Failed to load ADOMD.NET from %s: %s", dll, e)
+                logger.warning("Failed to load ADOMD.NET from %s: %s", dll_adomd, e)
                 continue
 
     if adomd_loaded:

--- a/tests/test_adomd_loading.py
+++ b/tests/test_adomd_loading.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import importlib
+from unittest.mock import MagicMock
+
+
+def test_adomd_additional_references(monkeypatch, tmp_path):
+    monkeypatch.setenv("ADOMD_LIB_DIR", str(tmp_path))
+    monkeypatch.syspath_prepend(os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+    class DummyPythonnet:
+        def set_runtime(self, runtime):
+            pass
+    monkeypatch.setitem(sys.modules, "pythonnet", DummyPythonnet())
+    monkeypatch.setitem(sys.modules, "pyadomd", MagicMock())
+
+    add_refs = []
+
+    clr_mock = MagicMock()
+    clr_mock.AddReference.side_effect = lambda dll: add_refs.append(dll)
+    monkeypatch.setitem(sys.modules, "clr", clr_mock)
+
+    orig_exists = os.path.exists
+    monkeypatch.setattr(os.path, "exists", lambda p: True if p == str(tmp_path) else orig_exists(p))
+
+    orig_server = sys.modules.pop("server", None)
+    server = importlib.import_module("server")
+    expected = [
+        str(tmp_path / "Microsoft.AnalysisServices.Platform.Core.dll"),
+        str(tmp_path / "Microsoft.AnalysisServices.Platform.Windows.dll"),
+        str(tmp_path / "Microsoft.AnalysisServices.AdomdClient.dll"),
+    ]
+    try:
+        assert server.adomd_loaded is True
+        assert add_refs == expected
+    finally:
+        if orig_server is not None:
+            sys.modules["server"] = orig_server
+        else:
+            sys.modules.pop("server", None)


### PR DESCRIPTION
## Summary
- add references to Microsoft.AnalysisServices.Platform.Core and Platform.Windows when loading ADOMD.NET
- include a regression test ensuring all assemblies are referenced

## Testing
- `pytest -q`
- `docker build -t powerbi-mcp .` *(fails: command not found)*
- `docker run --rm -e OPENAI_API_KEY=dummy powerbi-mcp timeout 5 python src/server.py` *(not run: docker not available)*

------
https://chatgpt.com/codex/tasks/task_b_6874ad512bac8329a8bd3f1a812377a2