### PR TITLE
Add ADOMD path to PATH env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && \
 ENV DOTNET_ROOT=/usr/share/dotnet \
     PYTHONNET_RUNTIME=coreclr \
     ADOMD_LIB_DIR=/usr/lib/adomd/lib/netcoreapp3.0 \
-    PATH="$PATH:/usr/share/dotnet"
+    PATH="$PATH:/usr/share/dotnet:/usr/lib/adomd/lib/netcoreapp3.0"
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- expose ADOMD.NET libraries on the PATH

## Testing
- `pytest -q`
- `docker build -t powerbi-mcp .` *(fails: command not found)*
- `docker run --rm -e OPENAI_API_KEY=dummy powerbi-mcp timeout 5 python src/server.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6874b39087288329aeaf32a00c603eb0