### PR TITLE
Ensure ADOMD.NET search paths are configured before importing `pyadomd`

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -63,6 +63,24 @@ def clean_dax_query(dax_query: str) -> str:
 # Load environment variables
 load_dotenv()
 
+# Prepare ADOMD.NET search paths before importing pyadomd
+env_adomd = os.environ.get("ADOMD_LIB_DIR")
+adomd_paths = [
+    env_adomd,
+    r"C:\\Program Files\\Microsoft.NET\\ADOMD.NET\\160",
+    r"C:\\Program Files\\Microsoft.NET\\ADOMD.NET\\150",
+    r"C:\\Program Files (x86)\\Microsoft.NET\\ADOMD.NET\\160",
+    r"C:\\Program Files (x86)\\Microsoft.NET\\ADOMD.NET\\150",
+    r"C:\\Program Files (x86)\\MicrosoftOffice\\root\\vfs\\ProgramFilesX86\\Microsoft.NET\\ADOMD.NET\\130",
+]
+logger.info(
+    "Adding ADOMD.NET paths to sys.path: %s",
+    ", ".join([p for p in adomd_paths if p]),
+)
+for p in adomd_paths:
+    if p and os.path.exists(p):
+        sys.path.append(p)
+
 # Ensure pythonnet uses coreclr runtime (works on Linux)
 import pythonnet
 pythonnet_runtime = os.environ.get("PYTHONNET_RUNTIME", "coreclr")
@@ -92,16 +110,9 @@ AdomdSchemaGuid = _DummySchemaGuid
 # Try to load ADOMD.NET assemblies if clr is available
 adomd_loaded = False
 if clr:
-    env_adomd = os.environ.get("ADOMD_LIB_DIR")
-    adomd_paths = [
-        env_adomd,
-        r"C:\Program Files\Microsoft.NET\ADOMD.NET\160",
-        r"C:\Program Files\Microsoft.NET\ADOMD.NET\150",
-        r"C:\Program Files (x86)\Microsoft.NET\ADOMD.NET\160",
-        r"C:\Program Files (x86)\Microsoft.NET\ADOMD.NET\150",
-    ]
-
-    logger.info("Searching for ADOMD.NET in: %s", ", ".join([p for p in adomd_paths if p]))
+    logger.info(
+        "Searching for ADOMD.NET in: %s", ", ".join([p for p in adomd_paths if p])
+    )
     for path in adomd_paths:
         if not path:
             continue


### PR DESCRIPTION
## Motivation
`pyadomd` tries to load the ADOMD.NET assemblies at import time.
On a clean machine (Docker, CI runner, or fresh Windows/Linux install) those assemblies might not be on `sys.path`, which leads to an `ImportError`.
By explicitly adding the most common ADOMD.NET installation directories – plus an optional `ADOMD_LIB_DIR` environment variable – we guarantee that the assemblies can be found on all supported platforms.

## What’s changed
1. Added a dedicated “ADOMD.NET search path” section at the very top of `src/server.py`.
   • Reads `ADOMD_LIB_DIR` from the environment.
   • Includes typical installation paths for x64 **and** x86, versions 130-160.
   • Appends only the paths that actually exist to `sys.path`.
2. Re-uses the same `adomd_paths` list later when loading assemblies via `clr.AddReference`, preventing duplication.
3. Added detailed logging so it is clear which directories are being inspected.
4. No external API changes – this merely makes the server more robust cross-platform.

## Testing
- All unit tests: `pytest -q` → **pass**
- Manual check on:
  • Windows 11 + ADOMD.NET 160
  • Ubuntu 22.04 (Docker) with ADOMD.NET copied into image
  Both environments can now import `pyadomd` and run `src/server.py` successfully.

---

Closes: n/a