### PR TITLE
Add Microsoft.Identity.Client to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,11 @@ RUN apt-get update && \
     mkdir -p /usr/lib/adomd && \
     wget -q https://www.nuget.org/api/v2/package/Microsoft.AnalysisServices.AdomdClient.netcore.retail.amd64/19.12.7-preview -O /tmp/adomd.nupkg && \
     unzip -q /tmp/adomd.nupkg -d /usr/lib/adomd && \
-    rm /tmp/adomd.nupkg
+    rm /tmp/adomd.nupkg && \
+    wget -q https://www.nuget.org/api/v2/package/Microsoft.Identity.Client/4.6.0 -O /tmp/msal.nupkg && \
+    unzip -q /tmp/msal.nupkg -d /tmp/msal && \
+    cp /tmp/msal/lib/netcoreapp2.1/Microsoft.Identity.Client.dll /usr/lib/adomd/lib/netcoreapp3.0/ && \
+    rm -rf /tmp/msal /tmp/msal.nupkg
 
 # Configure pythonnet to use the installed .NET runtime
 ENV DOTNET_ROOT=/usr/share/dotnet \

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -38,6 +38,19 @@ ImportError: Could not load ADOMD.NET library. Please install SSMS or ADOMD.NET 
    C:\Program Files (x86)\Microsoft.NET\ADOMD.NET\160
    C:\Program Files (x86)\Microsoft.NET\ADOMD.NET\150
    ```
+### Microsoft.Identity.Client Missing
+
+**Error:**
+```
+FileNotFoundException: Could not load file or assembly 'Microsoft.Identity.Client, Version=4.6.0.0'
+```
+
+**Solutions:**
+1. **Install Recent ADOMD.NET** - version 19.12 or newer bundles this library
+2. **Verify `ADOMD_LIB_DIR`** - point it to the folder with `Microsoft.Identity.Client.dll`
+3. **Restart the MCP server** after installation
+4. **Use the provided Dockerfile** - the container now installs this library automatically
+
 
 ### MCP Framework Not Found
 


### PR DESCRIPTION
## Summary
- install Microsoft.Identity.Client when building the Docker image
- note in troubleshooting doc that the Dockerfile handles this library

## Testing
- `pytest -q`
- `docker build -t powerbi-mcp .` *(fails: command not found)*
- `docker run --rm -e OPENAI_API_KEY=dummy powerbi-mcp timeout 5 python src/server.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6874ca8318c48329aae8e58789be29c2