### PR TITLE
feat(server): Make OpenAI integration optional and hide GPT tools when key is absent

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,10 @@
 # Copy this file to .env and fill in your actual values
 
 # ====================
-# REQUIRED: OpenAI Configuration
+# OPTIONAL: OpenAI Configuration (for natural language features)
 # ====================
 # Get your API key from https://platform.openai.com/api-keys
+# Leave blank to disable GPT-powered features (related endpoints hidden)
 OPENAI_API_KEY=sk-proj-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # Optional: Change model (defaults to gpt-4o-mini for cost efficiency)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ A Model Context Protocol (MCP) server that enables AI assistants to interact wit
 - SQL Server Management Studio (SSMS) or ADOMD.NET client libraries (Windows only)
 - Power BI Pro/Premium with XMLA endpoint enabled
 - Azure AD Service Principal with access to your Power BI dataset
-- OpenAI API key
+- OpenAI API key (optional for natural language features)
 
 ### Installation
 
@@ -152,18 +152,20 @@ Execute DAX: EVALUATE SUMMARIZE(Sales, Product[Category], "Total", SUM(Sales[Amo
    - Create in Azure Portal → App Registrations
    - Grant access in Power BI Workspace → Access settings
 
-3. **OpenAI API Key**
+3. **OpenAI API Key** *(optional)*
+   - Needed only for natural language features
+   - Endpoints that rely on GPT models are hidden if this key is not set
    - Get from [OpenAI Platform](https://platform.openai.com)
    - Model used: `gpt-4o-mini` (200x cheaper than GPT-4)
 
 ### Environment Variables
 
-Create a `.env` file:
+Create a `.env` file (OpenAI settings are optional):
 
 ```env
-# OpenAI Configuration
+# OpenAI Configuration (optional)
 OPENAI_API_KEY=your_openai_api_key_here
-OPENAI_MODEL=gpt-4o-mini  # Optional: defaults to gpt-4o-mini
+OPENAI_MODEL=gpt-4o-mini  # Defaults to gpt-4o-mini
 
 # Optional: Default Power BI Credentials
 DEFAULT_TENANT_ID=your_tenant_id

--- a/quickstart.py
+++ b/quickstart.py
@@ -115,14 +115,12 @@ def check_environment():
     # Load .env file
     load_dotenv()
     
-    # Check OpenAI API key
+    # Check OpenAI API key (optional)
     api_key = os.getenv("OPENAI_API_KEY")
     if api_key and api_key.startswith("sk-"):
         print(f"{Colors.GREEN}✓ OpenAI API key found{Colors.END}")
     else:
-        print(f"{Colors.RED}✗ OpenAI API key not found or invalid{Colors.END}")
-        print(f"{Colors.YELLOW}Add OPENAI_API_KEY to your .env file{Colors.END}")
-        return False
+        print(f"{Colors.YELLOW}ℹ OpenAI API key not set - natural language features will be disabled{Colors.END}")
     
     # Check optional Power BI credentials
     tenant_id = os.getenv("DEFAULT_TENANT_ID")

--- a/tests/test_openai_optional.py
+++ b/tests/test_openai_optional.py
@@ -1,0 +1,69 @@
+import os
+import pytest
+import asyncio
+from mcp import types as mcp_types
+
+# Add src to path for imports
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from server import PowerBIMCPServer
+
+@pytest.mark.asyncio
+async def test_connect_without_openai(monkeypatch):
+    server = PowerBIMCPServer()
+
+    # Patch connector.connect to avoid real connection
+    def fake_connect(xmla, tenant, client, secret, catalog):
+        return True
+    monkeypatch.setattr(server.connector, 'connect', fake_connect)
+
+    # Track if context preparation was called
+    called = False
+    async def fake_prepare():
+        nonlocal called
+        called = True
+    monkeypatch.setattr(server, '_async_prepare_context', fake_prepare)
+
+    # Ensure OPENAI_API_KEY is not set
+    monkeypatch.delenv('OPENAI_API_KEY', raising=False)
+
+    result = await server._handle_connect({
+        'xmla_endpoint': 'powerbi://test',
+        'tenant_id': 't',
+        'client_id': 'c',
+        'client_secret': 's',
+        'initial_catalog': 'd'
+    })
+
+    assert 'Successfully connected' in result
+    assert server.is_connected is True
+    assert server.analyzer is None
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_list_tools_without_openai(monkeypatch):
+    monkeypatch.delenv('OPENAI_API_KEY', raising=False)
+    server = PowerBIMCPServer()
+    handler = server.server.request_handlers[mcp_types.ListToolsRequest]
+    result = await handler(mcp_types.ListToolsRequest(method='tools/list'))
+    tool_names = [t.name for t in result.root.tools]
+    assert 'query_data' not in tool_names
+    assert 'suggest_questions' not in tool_names
+
+
+@pytest.mark.asyncio
+async def test_call_query_data_without_openai(monkeypatch):
+    monkeypatch.delenv('OPENAI_API_KEY', raising=False)
+    server = PowerBIMCPServer()
+    handler = server.server.request_handlers[mcp_types.CallToolRequest]
+    req = mcp_types.CallToolRequest(
+        method='tools/call',
+        params=mcp_types.CallToolRequestParams(
+            name='query_data', arguments={'question': 'hi'}
+        )
+    )
+    result = await handler(req)
+    text = result.root.content[0].text
+    assert 'OpenAI API key not configured' in text


### PR DESCRIPTION
## Overview
This PR makes the OpenAI dependency optional so that the MCP server can be started in environments **without** an `OPENAI_API_KEY`.  When the key is missing all GPT-powered functionality is gracefully disabled while the rest of the server continues to work as before.

## Key Changes
1. **Conditional feature flag**
   * Added `PowerBIMCPServer._openai_enabled()` helper to detect whether an API key is configured.
   * `tools/list` now returns `query_data` and `suggest_questions` **only** if GPT support is enabled.
   * `tools/call` handlers for `query_data` and `suggest_questions` short-circuit with a helpful message when GPT is disabled.
2. **Connection flow**
   * `connect_powerbi` no longer fails if the key is missing; the `DataAnalyzer` is initialised only when GPT support is available.
   * Context discovery (`_async_prepare_context`) is skipped when the analyzer is not present.
3. **Documentation & DX**
   * `.env.example`, `README.md` and `quickstart.py` rewritten to highlight that the OpenAI key is optional and what features are affected.
4. **Tests**
   * New `tests/test_openai_optional.py` verifies:
     - Successful connection without a key.
     - GPT tools are not exposed via `tools/list`.
     - Direct calls to a GPT tool return a helpful error message.
5. **Misc**
   * Improved log messages for clearer troubleshooting.

## Motivation
Many users want to run the server for purely tabular or BI workloads where GPT-powered natural-language features are unnecessary. Making the key optional lowers the barrier to entry and simplifies local / CI setups.

## Backwards Compatibility
* **No breaking changes.** When `OPENAI_API_KEY` *is* provided the behaviour is identical to previous versions.
* When the key is absent the only difference is that GPT-dependent endpoints are hidden or return an explanatory message instead of raising an error.

## Testing Notes
```bash
pytest -q                       # all tests (including new ones) pass
mcp run src/server.py           # starts without OPENAI_API_KEY
```

---
Resolves internal request to allow operating without OpenAI credentials.