### PR TITLE
Add table metadata and relationships

### DIFF
--- a/tests/test_server_metadata.py
+++ b/tests/test_server_metadata.py
@@ -1,0 +1,67 @@
+import pytest
+
+# Add src to path
+import os
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from server import PowerBIMCPServer
+
+
+@pytest.mark.asyncio
+async def test_list_tables_includes_metadata(monkeypatch):
+    server = PowerBIMCPServer()
+    server.is_connected = True
+
+    monkeypatch.setattr(server.connector, 'discover_tables', lambda: ['Sales', 'Product'])
+    monkeypatch.setattr(
+        server.connector,
+        'get_table_descriptions',
+        lambda: {'Sales': 'Sales table', 'Product': 'Product table'}
+    )
+    monkeypatch.setattr(
+        server.connector,
+        'get_relationships',
+        lambda: [{
+            'from_table': 'Sales',
+            'from_column': 'ProductID',
+            'to_table': 'Product',
+            'to_column': 'ID'
+        }]
+    )
+
+    result = await server._handle_list_tables()
+
+    assert 'Sales table' in result
+    assert 'Sales.ProductID -> Product.ID' in result
+
+
+@pytest.mark.asyncio
+async def test_get_table_info_includes_metadata(monkeypatch):
+    server = PowerBIMCPServer()
+    server.is_connected = True
+
+    monkeypatch.setattr(
+        server.connector,
+        'get_table_schema',
+        lambda name: {'type': 'data_table', 'columns': ['ID', 'Name']}
+    )
+    monkeypatch.setattr(server.connector, 'get_sample_data', lambda n, num: [])
+    monkeypatch.setattr(server.connector, 'get_table_descriptions', lambda: {'Sales': 'Sales desc'})
+    monkeypatch.setattr(server.connector, 'get_column_descriptions', lambda t: {'ID': 'identifier', 'Name': ''})
+    monkeypatch.setattr(
+        server.connector,
+        'get_relationships_for_table',
+        lambda t: [{
+            'from_table': 'Sales',
+            'from_column': 'ProductID',
+            'to_table': 'Product',
+            'to_column': 'ID'
+        }]
+    )
+
+    result = await server._handle_get_table_info({'table_name': 'Sales'})
+
+    assert 'Description: Sales desc' in result
+    assert '- ID: identifier' in result
+    assert 'Sales.ProductID -> Product.ID' in result


### PR DESCRIPTION
## Summary
- support retrieving table descriptions, column descriptions and relationships
- expose metadata in list_tables and get_table_info actions
- add tests for connector metadata methods
- test server handlers for new metadata output

## Testing
- `pytest -q`
- `docker build -t powerbi-mcp .` *(fails: command not found)*
- `docker run --rm -e OPENAI_API_KEY=dummy powerbi-mcp timeout 5 python src/server.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6877532345448329b659481cda848d4c