### PR TITLE
ci: publish Docker image to GHCR on push to main/master

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,57 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [ main, master ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME_LOWER: ${{ toLower(github.repository) }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract Docker metadata (tags, labels)
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LOWER }}
+        tags: |
+          type=ref,event=branch
+          type=ref,event=tag
+          type=raw,value=latest,enable={{is_default_branch}}
+          type=sha,format=short
+
+    # Note: Building only linux/amd64 due to ADOMD.NET retail package being amd64-only.
+    # If/when upstream ARM packages are supported, add linux/arm64 here.
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        platforms: linux/amd64
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+


### PR DESCRIPTION
This PR adds a workflow that builds and pushes the Docker image to GitHub Container Registry (GHCR) on every push to the default branch. 

Highlights:
- Logs in to ghcr.io using GITHUB_TOKEN.
- Tags images with branch, tag, latest (on default), and short SHA.
- Builds for linux/amd64 due to ADOMD.NET amd64 limitation.
- Uses GHA cache for faster rebuilds.

After merging, pushes to master/main will publish a new image to ghcr.io/jpierzchala/powerbi-mcp.