### PR TITLE
ci: gate GHCR publish on Tests success; publish tested commit

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,57 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [ main, master ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME_LOWER: ${{ toLower(github.repository) }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract Docker metadata (tags, labels)
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LOWER }}
+        tags: |
+          type=ref,event=branch
+          type=ref,event=tag
+          type=raw,value=latest,enable={{is_default_branch}}
+          type=sha,format=short
+
+    # Note: Building only linux/amd64 due to ADOMD.NET retail package being amd64-only.
+    # If/when upstream ARM packages are supported, add linux/arm64 here.
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        platforms: linux/amd64
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -43,16 +43,38 @@ jobs:
     - name: Compute tags
       id: meta
       shell: bash
+      env:
+        HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        PR_HEAD_REF: ${{ github.event.workflow_run.pull_requests[0].head.ref }}
+        RUN_REF: ${{ github.event.workflow_run.ref }}
+        DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
       run: |
+        set -euo pipefail
+
         IMAGE="${{ steps.vars.outputs.image }}"
-        BRANCH="${{ github.event.workflow_run.head_branch }}"
-        SHA="${{ github.event.workflow_run.head_sha }}"
+
+        BRANCH="${HEAD_BRANCH:-}"
+        if [[ -z "${BRANCH}" ]]; then
+          BRANCH="${PR_HEAD_REF:-}"
+        fi
+        if [[ -z "${BRANCH}" ]]; then
+          REF_VAL="${RUN_REF:-}"
+          if [[ "${REF_VAL}" =~ refs/heads/(.*) ]]; then
+            BRANCH="${BASH_REMATCH[1]}"
+          fi
+        fi
+        if [[ -z "${BRANCH}" ]]; then
+          BRANCH="unknown"
+        fi
+
+        SHA="${HEAD_SHA}"
         SHORT_SHA="${SHA:0:7}"
 
         TAGS=()
         TAGS+=("${IMAGE}:${BRANCH}")
         TAGS+=("${IMAGE}:sha-${SHORT_SHA}")
-        if [[ "${BRANCH}" == "master" || "${BRANCH}" == "main" ]]; then
+        if [[ "${BRANCH}" == "${DEFAULT_BRANCH}" ]]; then
           TAGS+=("${IMAGE}:latest")
         fi
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,7 +1,9 @@
 name: Build and Push Docker Image
 
 on:
-  push:
+  workflow_run:
+    workflows: [ "Tests" ]
+    types: [ completed ]
     branches: [ main, master ]
 
 env:
@@ -11,13 +13,16 @@ env:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: read
       packages: write
 
     steps:
-    - name: Checkout repository
+    - name: Checkout repository at tested commit
       uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.workflow_run.head_sha }}
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -35,16 +40,27 @@ jobs:
       run: |
         REPO="${{ github.repository }}"
         echo "image=ghcr.io/${REPO,,}" >> "$GITHUB_OUTPUT"
-    - name: Extract Docker metadata (tags, labels)
+    - name: Compute tags
       id: meta
-      uses: docker/metadata-action@v5
-      with:
-        images: ${{ steps.vars.outputs.image }}
-        tags: |
-          type=ref,event=branch
-          type=ref,event=tag
-          type=raw,value=latest,enable={{is_default_branch}}
-          type=sha,format=short
+      shell: bash
+      run: |
+        IMAGE="${{ steps.vars.outputs.image }}"
+        BRANCH="${{ github.event.workflow_run.head_branch }}"
+        SHA="${{ github.event.workflow_run.head_sha }}"
+        SHORT_SHA="${SHA:0:7}"
+
+        TAGS=()
+        TAGS+=("${IMAGE}:${BRANCH}")
+        TAGS+=("${IMAGE}:sha-${SHORT_SHA}")
+        if [[ "${BRANCH}" == "master" || "${BRANCH}" == "main" ]]; then
+          TAGS+=("${IMAGE}:latest")
+        fi
+
+        {
+          echo 'tags<<EOF'
+          printf '%s\n' "${TAGS[@]}"
+          echo 'EOF'
+        } >> "$GITHUB_OUTPUT"
 
     # Note: Building only linux/amd64 due to ADOMD.NET retail package being amd64-only.
     # If/when upstream ARM packages are supported, add linux/arm64 here.
@@ -55,7 +71,6 @@ jobs:
         platforms: linux/amd64
         push: true
         tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,7 +7,6 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  IMAGE_NAME_LOWER: ${{ toLower(github.repository) }}
 
 jobs:
   build-and-push:
@@ -30,11 +29,18 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Compute lowercase image name
+      id: vars
+      shell: bash
+      run: |
+        REPO="${{ github.repository }}"
+        echo "image=ghcr.io/${REPO,,}" >> "$GITHUB_OUTPUT"
+
     - name: Extract Docker metadata (tags, labels)
       id: meta
       uses: docker/metadata-action@v5
       with:
-        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LOWER }}
+        images: ${{ steps.vars.outputs.image }}
         tags: |
           type=ref,event=branch
           type=ref,event=tag

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -54,22 +54,17 @@ jobs:
 
         IMAGE="${{ steps.vars.outputs.image }}"
 
-        BRANCH="${HEAD_BRANCH:-}"
-        if [[ -z "${BRANCH}" ]]; then
-          BRANCH="${PR_HEAD_REF:-}"
-        fi
-        if [[ -z "${BRANCH}" ]]; then
-          REF_VAL="${RUN_REF:-}"
-          if [[ "${REF_VAL}" =~ refs/heads/(.*) ]]; then
-            BRANCH="${BASH_REMATCH[1]}"
-          fi
-        fi
-        if [[ -z "${BRANCH}" ]]; then
-          BRANCH="unknown"
+        # Simplified branch detection with fallbacks
+        BRANCH="${HEAD_BRANCH:-${PR_HEAD_REF:-}}"
+        if [[ -z "${BRANCH}" && -n "${RUN_REF:-}" && "${RUN_REF}" =~ refs/heads/(.*) ]]; then
+          BRANCH="${BASH_REMATCH[1]}"
         fi
 
         SHA="${HEAD_SHA}"
         SHORT_SHA="${SHA:0:7}"
+        if [[ -z "${BRANCH}" ]]; then
+          BRANCH="fallback-${SHORT_SHA}"
+        fi
 
         TAGS=()
         TAGS+=("${IMAGE}:${BRANCH}")

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -45,7 +45,6 @@ jobs:
       shell: bash
       env:
         HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-        PR_HEAD_REF: ${{ github.event.workflow_run.pull_requests[0].head.ref }}
         RUN_REF: ${{ github.event.workflow_run.ref }}
         DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
@@ -54,17 +53,19 @@ jobs:
 
         IMAGE="${{ steps.vars.outputs.image }}"
 
-        # Simplified branch detection with fallbacks
-        BRANCH="${HEAD_BRANCH:-${PR_HEAD_REF:-}}"
+        # Detect branch for workflow_run on default branch
+        BRANCH="${HEAD_BRANCH:-}"
         if [[ -z "${BRANCH}" && -n "${RUN_REF:-}" && "${RUN_REF}" =~ refs/heads/(.*) ]]; then
           BRANCH="${BASH_REMATCH[1]}"
         fi
 
+        if [[ -z "${BRANCH}" ]]; then
+          echo "Branch could not be determined; failing to avoid ambiguous tags" >&2
+          exit 1
+        fi
+
         SHA="${HEAD_SHA}"
         SHORT_SHA="${SHA:0:7}"
-        if [[ -z "${BRANCH}" ]]; then
-          BRANCH="fallback-${SHORT_SHA}"
-        fi
 
         TAGS=()
         TAGS+=("${IMAGE}:${BRANCH}")


### PR DESCRIPTION
This PR adjusts the Docker publish workflow to run only after the "Tests" workflow completes successfully on master/main. It checks out the tested head SHA, computes lowercase image name and deterministic tags (branch, short SHA, latest on default).

After merge, pushes to master/main will first run tests and only on success will build and push the Docker image to GHCR.